### PR TITLE
Add PHPUnit tests setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^9"
+    },
+    "autoload": {
+        "psr-4": {
+            "SchoolSportsAPI\\": "includes/",
+            "SchoolSportsAPI\\Admin\\": "admin/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "platform": {
+            "php": "8.1"
+        }
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="SchoolSportsAPITests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/RealtimeTest.php
+++ b/tests/RealtimeTest.php
@@ -1,0 +1,46 @@
+<?php
+require_once __DIR__.'/../includes/class-school-sports-api-realtime.php';
+require_once __DIR__.'/../includes/class-school-sports-api-api.php';
+
+use PHPUnit\Framework\TestCase;
+
+class RealtimeTest extends TestCase {
+    public function setUp(): void {
+        $this->realtime = new School_Sports_API_Realtime('school-sports-api', '1.0.0');
+    }
+
+    public function testDetectChangesWhenResultChanges() {
+        $old = [[
+            'naziv' => 'Sport',
+            'natjecanja' => [[
+                'faza' => [[
+                    'grupa' => [[
+                        'utakmice' => [[
+                            'brojUtakmice' => 1,
+                            'rezultatPrikaz' => '1:0'
+                        ]]
+                    ]]
+                ]]
+            ]]
+        ]];
+        $new = [[
+            'naziv' => 'Sport',
+            'natjecanja' => [[
+                'faza' => [[
+                    'grupa' => [[
+                        'utakmice' => [[
+                            'brojUtakmice' => 1,
+                            'rezultatPrikaz' => '2:0'
+                        ]]
+                    ]]
+                ]]
+            ]]
+        ]];
+        $ref = new ReflectionClass($this->realtime);
+        $method = $ref->getMethod('detect_changes');
+        $method->setAccessible(true);
+        $changes = $method->invoke($this->realtime, $old, $new);
+        $this->assertNotEmpty($changes);
+        $this->assertEquals('result_changed', $changes[0]['type']);
+    }
+}

--- a/tests/ShortcodesTest.php
+++ b/tests/ShortcodesTest.php
@@ -1,0 +1,41 @@
+<?php
+require_once __DIR__.'/../includes/class-school-sports-api-shortcodes.php';
+
+use PHPUnit\Framework\TestCase;
+
+class ShortcodesTest extends TestCase {
+    public function setUp(): void {
+        $this->shortcodes = new School_Sports_API_Shortcodes('school-sports-api', '1.0.0');
+    }
+
+    public function testFilterBySchoolTypeHighSchool() {
+        $data = [
+            ['natjecanje' => ['spol' => 'Mladići']],
+            ['natjecanje' => ['spol' => 'Djevojke']],
+            ['natjecanje' => ['spol' => 'Dječaci']],
+        ];
+        $filtered = $this->invokeFilter($data, 'ss');
+        $this->assertCount(2, $filtered);
+        $this->assertEquals('Mladići', $filtered[0]['natjecanje']['spol']);
+        $this->assertEquals('Djevojke', $filtered[1]['natjecanje']['spol']);
+    }
+
+    public function testFilterBySchoolTypeElementary() {
+        $data = [
+            ['natjecanje' => ['spol' => 'Dječaci']],
+            ['natjecanje' => ['spol' => 'Djevojčice']],
+            ['natjecanje' => ['spol' => 'Mladići']],
+        ];
+        $filtered = $this->invokeFilter($data, 'os');
+        $this->assertCount(2, $filtered);
+        $this->assertEquals('Dječaci', $filtered[0]['natjecanje']['spol']);
+        $this->assertEquals('Djevojčice', $filtered[1]['natjecanje']['spol']);
+    }
+
+    private function invokeFilter($data, $type) {
+        $ref = new ReflectionClass($this->shortcodes);
+        $method = $ref->getMethod('filter_by_school_type');
+        $method->setAccessible(true);
+        return $method->invoke($this->shortcodes, $data, $type);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+// Minimal WordPress function stubs needed for tests
+function __($text, $domain = null) {
+    return $text;
+}
+function _e($text, $domain = null) {
+    echo $text;
+}
+function add_filter($hook, $callback, $priority = 10, $args = 1) {}
+function remove_filter($hook, $callback, $priority = 10) {}
+function add_action($hook, $callback, $priority = 10, $args = 1) {}
+function wp_kses($string, $allowed_html, $allowed_protocols = array()) { return $string; }
+function sanitize_title($title) { return strtolower(preg_replace('/[^a-z0-9]+/i', '-', trim($title))); }
+function get_option($name) { return array(); }
+function set_transient($key, $value, $expiration) { return true; }
+function get_transient($key) { return false; }
+function delete_transient($key) { return true; }
+function wp_strip_all_tags($string) { return strip_tags($string); }
+?>


### PR DESCRIPTION
## Summary
- add composer config for phpunit
- configure phpunit bootstrap
- write unit tests for shortcodes filtering and realtime change detection

## Testing
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f8613cb988332a82a0eed34e3f9a6