### PR TITLE
Fix CLI debug scripts

### DIFF
--- a/debug-verbose.php
+++ b/debug-verbose.php
@@ -26,10 +26,10 @@ echo "Starting plugin debug...\n\n";
 function check_file_exists($file_path) {
     $full_path = PLUGIN_PATH . '/' . $file_path;
     if (file_exists($full_path)) {
-        echo esc_html("✓ File exists: {$file_path}\n");
+        echo htmlspecialchars("✓ File exists: {$file_path}\n", ENT_QUOTES, 'UTF-8');
         return true;
     } else {
-        echo esc_html("✗ File MISSING: {$file_path}\n");
+        echo htmlspecialchars("✗ File MISSING: {$file_path}\n", ENT_QUOTES, 'UTF-8');
         return false;
     }
 }
@@ -43,11 +43,11 @@ function check_syntax($file_path) {
     
     $output = shell_exec("php -l \"{$full_path}\" 2>&1");
     if (strpos($output, 'No syntax errors detected') !== false) {
-        echo esc_html("✓ Syntax OK: {$file_path}\n");
+        echo htmlspecialchars("✓ Syntax OK: {$file_path}\n", ENT_QUOTES, 'UTF-8');
         return true;
     } else {
-        echo esc_html("✗ Syntax ERROR in {$file_path}:\n");
-        echo esc_html($output . "\n");
+        echo htmlspecialchars("✗ Syntax ERROR in {$file_path}:\n", ENT_QUOTES, 'UTF-8');
+        echo htmlspecialchars($output . "\n", ENT_QUOTES, 'UTF-8');
         return false;
     }
 }
@@ -116,16 +116,16 @@ try {
     error_reporting($old_error_level);
     
     if (empty($output)) {
-        echo esc_html("✓ Main plugin file included successfully.\n");
+        echo htmlspecialchars("✓ Main plugin file included successfully.\n", ENT_QUOTES, 'UTF-8');
     } else {
-        echo esc_html("✗ Errors when including main plugin file:\n");
-        echo esc_html($output . "\n");
+        echo htmlspecialchars("✗ Errors when including main plugin file:\n", ENT_QUOTES, 'UTF-8');
+        echo htmlspecialchars($output . "\n", ENT_QUOTES, 'UTF-8');
     }
 } catch (Throwable $e) {
     // Catch any exceptions
     ob_end_clean();
-    echo esc_html("✗ Exception when including main plugin file:\n");
-    echo esc_html($e->getMessage() . " in " . $e->getFile() . " on line " . $e->getLine() . "\n");
+    echo htmlspecialchars("✗ Exception when including main plugin file:\n", ENT_QUOTES, 'UTF-8');
+    echo htmlspecialchars($e->getMessage() . " in " . $e->getFile() . " on line " . $e->getLine() . "\n", ENT_QUOTES, 'UTF-8');
 }
 
 echo "\nDebug complete.\n";

--- a/debug.php
+++ b/debug.php
@@ -25,7 +25,7 @@ foreach ($files as $file) {
     $fullPath = __DIR__ . '/' . $file;
     
     if (!file_exists($fullPath)) {
-        echo esc_html("ERROR: File not found: {$file}\n");
+        echo htmlspecialchars("ERROR: File not found: {$file}\n", ENT_QUOTES, 'UTF-8');
         continue;
     }
     
@@ -35,11 +35,11 @@ foreach ($files as $file) {
     exec("php -l {$fullPath}", $output, $return_var);
     
     if ($return_var !== 0) {
-        echo esc_html("ERROR in {$file}:\n");
-        echo esc_html(implode("\n", $output) . "\n");
+        echo htmlspecialchars("ERROR in {$file}:\n", ENT_QUOTES, 'UTF-8');
+        echo htmlspecialchars(implode("\n", $output) . "\n", ENT_QUOTES, 'UTF-8');
     } else {
-        echo esc_html("OK: {$file}\n");
+        echo htmlspecialchars("OK: {$file}\n", ENT_QUOTES, 'UTF-8');
     }
 }
 
-echo esc_html("Syntax check complete.\n");
+echo htmlspecialchars("Syntax check complete.\n", ENT_QUOTES, 'UTF-8');


### PR DESCRIPTION
## Summary
- fix debug.php by removing reliance on WordPress functions
- fix debug-verbose.php similarly

## Testing
- `find . -name '*.php' | xargs -I{} php -l {} | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_687f87422be48332b0881b502f1d0413